### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Discord](https://img.shields.io/badge/discord-Phaetec-blue.svg)](https://discord.gg/W6rsEq2)
 [![CircleCI](https://img.shields.io/circleci/project/Phaetec/pogo-cruncher/master.svg?maxAge=60)](https://circleci.com/gh/Phaetec/pogo-cruncher)
 [![Github All Releases](https://img.shields.io/github/downloads/phaetec/pogo-cruncher/total.svg?maxAge=60)](https://github.com/Phaetec/pogo-cruncher/releases)
-[![Docker Pulls](https://img.shields.io/docker/pulls/phaetec/pogo-cruncher.svg?maxAge=60)](https://hub.docker.com/r/phaetec/pogo-cruncher/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/phaetec/pogo-cruncher.svg?maxAge=60)](https://hub.docker.com/r/phaetec/pogo-cruncher/) [![](https://images.microbadger.com/badges/image/phaetec/pogo-cruncher.svg)](https://microbadger.com/images/phaetec/pogo-cruncher "Get your own image badge on microbadger.com")
 [![GitHub release](https://img.shields.io/github/release/Phaetec/pogo-cruncher.svg?maxAge=60)](https://github.com/Phaetec/pogo-cruncher)
 
 **Please refrain of use of this tool, as there is a chance of getting banned at the moment. If we find a solution, we will make a version update and make a shoutout in our Discord channel.**
@@ -53,3 +53,4 @@ Active Maintainers:
 
 ## Feature Requests
 For feature requests please open up a new issue on this repository.
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [phaetec/pogo-cruncher](https://hub.docker.com/r/phaetec/pogo-cruncher/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/phaetec/pogo-cruncher).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/phaetec/pogo-cruncher.svg)](https://microbadger.com/images/phaetec/pogo-cruncher "Get your own image badge on microbadger.com")
